### PR TITLE
#3: Add support for generating a TODO file from tasks

### DIFF
--- a/findTodos.ts
+++ b/findTodos.ts
@@ -1,0 +1,58 @@
+/**
+ * TypeScript mirror of https://github.com/joeriddles/notes
+ */
+
+import { TFile } from "obsidian"
+
+interface Todo {
+  task: string
+  text: string
+  file: TFile
+}
+
+const TODO_PATTERN = /^\s*-\s?\[(?<task>.)\]\s+(?<text>.*)$/
+
+function parseTodos(file: TFile, contents: string): Todo[] {
+  const lines = contents.split(/[\r\n]+/)
+  const matches = lines
+    .map(line => line.match(TODO_PATTERN))
+    .filter(match => match != null) as RegExpMatchArray[]
+  const todos = matches.map(match => {
+    const task = match.groups?.task
+    const text = match.groups?.text
+    return { task, text, file } as Todo
+  })
+  return todos
+}
+
+async function saveTodos(file: TFile, todos: Todo[]): Promise<void> {
+  let data = ""
+
+  // Sort oldest-to-newest
+  todos.sort((a, b) => a.file.stat.mtime - b.file.stat.mtime)
+
+  // Group by file
+  const todosByFile: Map<TFile, Todo[]> = new Map();
+  todos.forEach(todo => {
+    if (!todosByFile.get(todo.file)) {
+      todosByFile.set(todo.file, [])
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    todosByFile.get(todo.file)!.push(todo)
+  })
+
+  todosByFile.forEach((todos, file) => {
+    const urlEncodedFilePath = encodeURI(file.path)
+    data += `- [${file.basename}](${urlEncodedFilePath})\n`
+    todos.forEach(todo => {
+      data += `    - [${todo.task}] ${todo.text}\n`
+    })
+  })
+
+  file.vault.modify(file, data)
+}
+
+export { parseTodos, saveTodos }
+export type { Todo }
+


### PR DESCRIPTION
closes #3

- Add support for generating a TODO file from tasks
    - Add settings to control generated TODO filepath
    - Add command "Extended Task Lists: Update TODO"

### Screenshots
Command
<img width="793" alt="image" src="https://github.com/joeriddles/extended-task-lists/assets/19392916/02221139-12ae-42ea-bca6-0f7a300a9ec0">

Generated file
<img width="793" alt="image" src="https://github.com/joeriddles/extended-task-lists/assets/19392916/caa04d9f-997a-451d-a417-9321a976fca2">


Settings
<img width="793" alt="image" src="https://github.com/joeriddles/extended-task-lists/assets/19392916/a2abc36b-4389-4dae-a901-8c017a6ab0ae">

