### PR TITLE
Exclude finished tasks by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
       "source.fixAll": "explicit"
     },
   },
-  "eslint.codeActionsOnSave.mode": "problems"
+  "eslint.codeActionsOnSave.mode": "problems",
+  "cSpell.words": [
+    "todos"
+  ]
 }

--- a/findTodos.ts
+++ b/findTodos.ts
@@ -12,47 +12,53 @@ interface Todo {
 
 const TODO_PATTERN = /^\s*-\s?\[(?<task>.)\]\s+(?<text>.*)$/
 
-function parseTodos(file: TFile, contents: string): Todo[] {
-  const lines = contents.split(/[\r\n]+/)
-  const matches = lines
-    .map(line => line.match(TODO_PATTERN))
-    .filter(match => match != null) as RegExpMatchArray[]
-  const todos = matches.map(match => {
-    const task = match.groups?.task
-    const text = match.groups?.text
-    return { task, text, file } as Todo
-  })
-  return todos
-}
+class TodoService {
 
-async function saveTodos(file: TFile, todos: Todo[]): Promise<void> {
-  let data = ""
+  constructor() { }
 
-  // Sort oldest-to-newest
-  todos.sort((a, b) => a.file.stat.mtime - b.file.stat.mtime)
-
-  // Group by file
-  const todosByFile: Map<TFile, Todo[]> = new Map();
-  todos.forEach(todo => {
-    if (!todosByFile.get(todo.file)) {
-      todosByFile.set(todo.file, [])
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    todosByFile.get(todo.file)!.push(todo)
-  })
-
-  todosByFile.forEach((todos, file) => {
-    const urlEncodedFilePath = encodeURI(file.path)
-    data += `- [${file.basename}](${urlEncodedFilePath})\n`
-    todos.forEach(todo => {
-      data += `    - [${todo.task}] ${todo.text}\n`
+  parseTodos(file: TFile, contents: string): Todo[] {
+    const lines = contents.split(/[\r\n]+/)
+    const matches = lines
+      .map(line => line.match(TODO_PATTERN))
+      .filter(match => match != null) as RegExpMatchArray[]
+    const todos = matches.map(match => {
+      const task = match.groups?.task
+      const text = match.groups?.text
+      return { task, text, file } as Todo
     })
-  })
+    return todos
+  }
 
-  file.vault.modify(file, data)
+  async saveTodos(file: TFile, todos: Todo[]): Promise<void> {
+    let data = ""
+
+    // Sort oldest-to-newest
+    todos.sort((a, b) => a.file.stat.mtime - b.file.stat.mtime)
+
+    // Group by file
+    const todosByFile: Map<TFile, Todo[]> = new Map();
+    todos.forEach(todo => {
+      if (!todosByFile.get(todo.file)) {
+        todosByFile.set(todo.file, [])
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      todosByFile.get(todo.file)!.push(todo)
+    })
+
+    todosByFile.forEach((todos, file) => {
+      const urlEncodedFilePath = encodeURI(file.path)
+      data += `- [${file.basename}](${urlEncodedFilePath})\n`
+      todos.forEach(todo => {
+        data += `    - [${todo.task}] ${todo.text}\n`
+      })
+    })
+
+    file.vault.modify(file, data)
+  }
 }
 
-export { parseTodos, saveTodos }
+
+export default TodoService
 export type { Todo }
 

--- a/findTodos.ts
+++ b/findTodos.ts
@@ -2,7 +2,8 @@
  * TypeScript mirror of https://github.com/joeriddles/notes
  */
 
-import { TFile } from "obsidian"
+import { TFile } from "obsidian";
+import { ExtendedTaskListsSettings } from 'settings';
 
 enum TaskType {
   NotStarted = " ",
@@ -20,8 +21,11 @@ interface Todo {
 const TODO_PATTERN = /^\s*-\s?\[(?<task>.)\]\s+(?<text>.*)$/
 
 class TodoService {
+  settings: ExtendedTaskListsSettings
 
-  constructor() { }
+  constructor(settings: ExtendedTaskListsSettings) {
+    this.settings = settings
+  }
 
   parseTodos(file: TFile, contents: string): Todo[] {
     const lines = contents.split(/[\r\n]+/)
@@ -43,7 +47,12 @@ class TodoService {
     todos.sort((a, b) => a.file.stat.mtime - b.file.stat.mtime)
 
     // Exclude finished tasks
-    todos = todos.filter(todo => todo.task !== TaskType.Done && todo.task !== TaskType.WontDo)
+    todos = todos.filter(todo =>
+      (todo.task === TaskType.NotStarted && this.settings.includeNotStarted)
+      || (todo.task === TaskType.InProgress && this.settings.includeInProgress)
+      || (todo.task === TaskType.WontDo && this.settings.includeWontDo)
+      || (todo.task === TaskType.Done && this.settings.includeDone)
+    )
 
     // Group by file
     const todosByFile: Map<TFile, Todo[]> = new Map();
@@ -70,5 +79,5 @@ class TodoService {
 
 
 export default TodoService
-export type { Todo }
+export type { Todo };
 

--- a/findTodos.ts
+++ b/findTodos.ts
@@ -4,8 +4,15 @@
 
 import { TFile } from "obsidian"
 
+enum TaskType {
+  NotStarted = " ",
+  InProgress = ".",
+  WontDo = "~",
+  Done = "x",
+}
+
 interface Todo {
-  task: string
+  task: TaskType
   text: string
   file: TFile
 }
@@ -34,6 +41,9 @@ class TodoService {
 
     // Sort oldest-to-newest
     todos.sort((a, b) => a.file.stat.mtime - b.file.stat.mtime)
+
+    // Exclude finished tasks
+    todos = todos.filter(todo => todo.task !== TaskType.Done && todo.task !== TaskType.WontDo)
 
     // Group by file
     const todosByFile: Map<TFile, Todo[]> = new Map();

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { App, Plugin, PluginSettingTab, Setting, TFile, Vault } from 'obsidian'
-import { Todo, parseTodos, saveTodos } from './findTodos'
+import TodoService, { Todo } from './findTodos'
 
 interface ExtendedTaskListsSettings {
 	todoFilename: string
@@ -84,15 +84,17 @@ export default class ExtendedTaskListsPlugin extends Plugin {
 	updateTodo = async () => {
 		const vault = this.app.vault
 
+		const service = new TodoService()
+
 		const markdownFiles = vault.getMarkdownFiles().filter(file => file.name != this.settings.todoFilename)
 		const todos: Todo[] = []
 		markdownFiles.forEach(async (file) => {
 			const contents = await vault.cachedRead(file)
-			todos.push(...parseTodos(file, contents))
+			todos.push(...service.parseTodos(file, contents))
 		})
 
 		const todoFile = await this.getOrCreateTodoFile(vault);
-		await saveTodos(todoFile, todos)
+		await service.saveTodos(todoFile, todos)
 	}
 
 	getOrCreateTodoFile = async (vault: Vault): Promise<TFile> => {

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,6 @@
-import { App, Plugin, PluginSettingTab, Setting, TFile, Vault } from 'obsidian'
-import TodoService, { Todo } from './findTodos'
-
-interface ExtendedTaskListsSettings {
-	todoFilename: string
-}
-
-const DEFAULT_SETTINGS: ExtendedTaskListsSettings = {
-	todoFilename: "TODO.md"
-}
+import { App, Plugin, PluginSettingTab, Setting, TFile, Vault } from 'obsidian';
+import { DEFAULT_SETTINGS, ExtendedTaskListsSettings } from 'settings';
+import TodoService, { Todo } from './findTodos';
 
 export default class ExtendedTaskListsPlugin extends Plugin {
 	settings: ExtendedTaskListsSettings
@@ -84,7 +77,7 @@ export default class ExtendedTaskListsPlugin extends Plugin {
 	updateTodo = async () => {
 		const vault = this.app.vault
 
-		const service = new TodoService()
+		const service = new TodoService(this.settings)
 
 		const markdownFiles = vault.getMarkdownFiles().filter(file => file.name != this.settings.todoFilename)
 		const todos: Todo[] = []
@@ -126,6 +119,7 @@ class ExtendedTaskListsSettingTab extends PluginSettingTab {
 		const { containerEl } = this
 
 		containerEl.empty()
+		this.containerEl.createEl("h2", { text: "Generated TODO" });
 
 		new Setting(containerEl)
 			.setName('TODO filename')
@@ -133,6 +127,42 @@ class ExtendedTaskListsSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.todoFilename)
 				.onChange(async (value) => {
 					this.plugin.settings.todoFilename = value
+					await this.plugin.saveSettings()
+				}))
+
+		new Setting(containerEl)
+			.setName('Include not started tasks')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.includeNotStarted)
+				.onChange(async (value) => {
+					this.plugin.settings.includeNotStarted = value
+					await this.plugin.saveSettings()
+				}))
+
+		new Setting(containerEl)
+			.setName('Include in progress tasks')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.includeInProgress)
+				.onChange(async (value) => {
+					this.plugin.settings.includeInProgress = value
+					await this.plugin.saveSettings()
+				}))
+
+		new Setting(containerEl)
+			.setName('Include won\'t do tasks')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.includeWontDo)
+				.onChange(async (value) => {
+					this.plugin.settings.includeWontDo = value
+					await this.plugin.saveSettings()
+				}))
+
+		new Setting(containerEl)
+			.setName('Include done tasks')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.includeDone)
+				.onChange(async (value) => {
+					this.plugin.settings.includeDone = value
 					await this.plugin.saveSettings()
 				}))
 	}

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,19 @@
+interface ExtendedTaskListsSettings {
+  todoFilename: string;
+  includeNotStarted: boolean;
+  includeInProgress: boolean;
+  includeWontDo: boolean;
+  includeDone: boolean;
+}
+
+const DEFAULT_SETTINGS: ExtendedTaskListsSettings = {
+  todoFilename: "TODO.md",
+  includeNotStarted: true,
+  includeInProgress: true,
+  includeWontDo: false,
+  includeDone: false,
+}
+
+export { DEFAULT_SETTINGS };
+export type { ExtendedTaskListsSettings };
+


### PR DESCRIPTION
closes #9

- Add and use settings for what task item types to include in generated TODO.md file
- Exclude finished tasks by default