### PR TITLE
#8: Support excluding Markdown files and folders from generated TODO file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Extended Task Lists
 
 ### To use
 
+#### Extra syntax
 Simply add an in-progress or won't do task item: 
 
 ```markdown
@@ -23,6 +24,13 @@ Simply add an in-progress or won't do task item:
 - [~] Won't do
 - [x] Done
 ```
+
+#### Generate `TODO.md`
+Open the command palette (`Ctrl/Cmd + P` by default) and run the "Extended Task Lists: Generate TODO" command.
+
+The generated filename can be configured in the plugin settings, as well as what task item types are included. By default, done and won't do task items are excluded.
+
+To exclude a markdown file's task items from being included in the generated TODO file, add `<!-- exclude TODO -->` anywhere in the markdown file. To exclude are markdown files in a folder, add an empty `.exclude_todos` file in the folder.
 
 ### Development
 

--- a/findTodos.ts
+++ b/findTodos.ts
@@ -2,7 +2,7 @@
  * TypeScript mirror of https://github.com/joeriddles/notes
  */
 
-import { TFile, Vault, normalizePath } from "obsidian";
+import { TAbstractFile, TFile, Vault, normalizePath } from "obsidian";
 import { ExtendedTaskListsSettings } from 'settings';
 
 enum TaskType {
@@ -103,7 +103,7 @@ class TodoService {
     file.vault.modify(file, data)
   }
 
-  private async getShouldExcludeFile(file: TFile): Promise<boolean> {
+  private async getShouldExcludeFile(file: TAbstractFile): Promise<boolean> {
     const isTodoFile = file.name == this.settings.todoFilename
     if (isTodoFile) {
       return true
@@ -121,6 +121,11 @@ class TodoService {
 
       excludeFolderFilepath = normalizePath(excludeFolderFilepath)
       isFolderExcluded = await this.vault.adapter.exists(excludeFolderFilepath)
+    }
+
+    // Recurse upwards to check if the file is deeply nested in an excluded folder
+    if (!isFolderExcluded && file.parent) {
+      isFolderExcluded = await this.getShouldExcludeFile(file.parent)
     }
 
     return isFolderExcluded

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
-import { App, Plugin, PluginSettingTab, Setting, TFile, Vault } from 'obsidian';
-import { DEFAULT_SETTINGS, ExtendedTaskListsSettings } from 'settings';
+import { Plugin, TFile, Vault } from 'obsidian';
+import { DEFAULT_SETTINGS, ExtendedTaskListsSettingTab, ExtendedTaskListsSettings } from 'settings';
 import TodoService, { Todo } from './findTodos';
 
 export default class ExtendedTaskListsPlugin extends Plugin {
@@ -76,11 +76,11 @@ export default class ExtendedTaskListsPlugin extends Plugin {
 
 	updateTodo = async () => {
 		const vault = this.app.vault
-		const service = new TodoService(this.settings)
-		const todoFiles = await service.findTodosFiles(vault)
+		const service = new TodoService(vault, this.settings)
+		const todoFiles = await service.findTodosFiles()
 		const todos: Todo[] = todoFiles
 			.map(todoFile => service.parseTodos(todoFile))
-			.reduce((prev, cur) => prev.concat(cur))
+			.reduce((prev, cur) => prev.concat(cur), [])
 		const todoFile = await this.getOrCreateTodoFile(vault);
 		await service.saveTodos(todoFile, todos)
 	}
@@ -102,63 +102,3 @@ export default class ExtendedTaskListsPlugin extends Plugin {
 	}
 }
 
-class ExtendedTaskListsSettingTab extends PluginSettingTab {
-	plugin: ExtendedTaskListsPlugin
-
-	constructor(app: App, plugin: ExtendedTaskListsPlugin) {
-		super(app, plugin)
-		this.plugin = plugin
-	}
-
-	display(): void {
-		const { containerEl } = this
-
-		containerEl.empty()
-		this.containerEl.createEl("h2", { text: "Generated TODO" });
-
-		new Setting(containerEl)
-			.setName('TODO filename')
-			.addText(text => text
-				.setValue(this.plugin.settings.todoFilename)
-				.onChange(async (value) => {
-					this.plugin.settings.todoFilename = value
-					await this.plugin.saveSettings()
-				}))
-
-		new Setting(containerEl)
-			.setName('Include not started tasks')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.includeNotStarted)
-				.onChange(async (value) => {
-					this.plugin.settings.includeNotStarted = value
-					await this.plugin.saveSettings()
-				}))
-
-		new Setting(containerEl)
-			.setName('Include in progress tasks')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.includeInProgress)
-				.onChange(async (value) => {
-					this.plugin.settings.includeInProgress = value
-					await this.plugin.saveSettings()
-				}))
-
-		new Setting(containerEl)
-			.setName('Include won\'t do tasks')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.includeWontDo)
-				.onChange(async (value) => {
-					this.plugin.settings.includeWontDo = value
-					await this.plugin.saveSettings()
-				}))
-
-		new Setting(containerEl)
-			.setName('Include done tasks')
-			.addToggle(toggle => toggle
-				.setValue(this.plugin.settings.includeDone)
-				.onChange(async (value) => {
-					this.plugin.settings.includeDone = value
-					await this.plugin.saveSettings()
-				}))
-	}
-}

--- a/main.ts
+++ b/main.ts
@@ -76,16 +76,11 @@ export default class ExtendedTaskListsPlugin extends Plugin {
 
 	updateTodo = async () => {
 		const vault = this.app.vault
-
 		const service = new TodoService(this.settings)
-
-		const markdownFiles = vault.getMarkdownFiles().filter(file => file.name != this.settings.todoFilename)
-		const todos: Todo[] = []
-		markdownFiles.forEach(async (file) => {
-			const contents = await vault.cachedRead(file)
-			todos.push(...service.parseTodos(file, contents))
-		})
-
+		const todoFiles = await service.findTodosFiles(vault)
+		const todos: Todo[] = todoFiles
+			.map(todoFile => service.parseTodos(todoFile))
+			.reduce((prev, cur) => prev.concat(cur))
 		const todoFile = await this.getOrCreateTodoFile(vault);
 		await service.saveTodos(todoFile, todos)
 	}

--- a/settings.ts
+++ b/settings.ts
@@ -1,5 +1,9 @@
+import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
+
 interface ExtendedTaskListsSettings {
   todoFilename: string;
+  excludeFilePattern: string;
+  excludeFolderFilename: string;
   includeNotStarted: boolean;
   includeInProgress: boolean;
   includeWontDo: boolean;
@@ -8,12 +12,102 @@ interface ExtendedTaskListsSettings {
 
 const DEFAULT_SETTINGS: ExtendedTaskListsSettings = {
   todoFilename: "TODO.md",
+  excludeFilePattern: "<!-- exclude TODO -->",
+  excludeFolderFilename: ".exclude_todos",
   includeNotStarted: true,
   includeInProgress: true,
   includeWontDo: false,
   includeDone: false,
 }
 
-export { DEFAULT_SETTINGS };
+export { DEFAULT_SETTINGS, ExtendedTaskListsSettingTab };
 export type { ExtendedTaskListsSettings };
 
+
+interface IPlugin extends Plugin {
+  settings: ExtendedTaskListsSettings
+
+  saveSettings(): Promise<void>
+}
+
+
+class ExtendedTaskListsSettingTab extends PluginSettingTab {
+  plugin: IPlugin
+
+  constructor(app: App, plugin: IPlugin) {
+    super(app, plugin)
+    this.plugin = plugin
+  }
+
+  display(): void {
+    const { containerEl } = this
+
+    containerEl.empty()
+    this.containerEl.createEl("h2", { text: "Generated TODO" });
+
+    new Setting(containerEl)
+      .setName('TODO filename')
+      .addText(text => text
+        .setValue(this.plugin.settings.todoFilename)
+        .onChange(async (value) => {
+          this.plugin.settings.todoFilename = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Exclude file pattern')
+      .setDesc('A pattern that should be inserted anywhere in a Markdown file to exclude it from the generated TODO file.')
+      .addText(text => text
+        .setValue(this.plugin.settings.excludeFilePattern)
+        .onChange(async (value) => {
+          this.plugin.settings.excludeFilePattern = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Exclude folder filename')
+      .setDesc('The filename to add to a folder to exclude all task lists in it from the generated TODO file. You may prefer to change the default value since dot files (files that start with a ".") do not show up within Obsidian.')
+      .addText(text => text
+        .setValue(this.plugin.settings.excludeFolderFilename)
+        .onChange(async (value) => {
+          this.plugin.settings.excludeFolderFilename = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Include not started tasks')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.includeNotStarted)
+        .onChange(async (value) => {
+          this.plugin.settings.includeNotStarted = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Include in progress tasks')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.includeInProgress)
+        .onChange(async (value) => {
+          this.plugin.settings.includeInProgress = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Include won\'t do tasks')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.includeWontDo)
+        .onChange(async (value) => {
+          this.plugin.settings.includeWontDo = value
+          await this.plugin.saveSettings()
+        }))
+
+    new Setting(containerEl)
+      .setName('Include done tasks')
+      .addToggle(toggle => toggle
+        .setValue(this.plugin.settings.includeDone)
+        .onChange(async (value) => {
+          this.plugin.settings.includeDone = value
+          await this.plugin.saveSettings()
+        }))
+  }
+}


### PR DESCRIPTION
closes #8

- Add setting for the filename to exclude a folder
- Add settings for the line pattern to exclude a file
- Add excluding files and folders from the generated TODO file using the above settings
