### PR TITLE
#15: Fix nested indentation

### DIFF
--- a/src/todoService.test.ts
+++ b/src/todoService.test.ts
@@ -157,21 +157,25 @@ describe("TodoService", () => {
         task: TaskType.NotStarted,
         text: "Pending",
         indentation: "",
+        lineno: 1,
       } as Todo,
       {
         task: TaskType.InProgress,
         text: "In progress",
         indentation: "",
+        lineno: 2,
       } as Todo,
       {
         task: TaskType.WontDo,
         text: "Won't do",
         indentation: "",
+        lineno: 3,
       } as Todo,
       {
         task: TaskType.Done,
         text: "Done",
         indentation: "",
+        lineno: 4,
       } as Todo,
     ]
 
@@ -198,21 +202,25 @@ describe("TodoService", () => {
         task: TaskType.NotStarted,
         text: "Pending",
         indentation: "",
+        lineno: 1,
       } as Todo,
       {
         task: TaskType.InProgress,
         text: "In progress",
         indentation: "    ",
+        lineno: 2,
       } as Todo,
       {
         task: TaskType.WontDo,
         text: "Won't do",
         indentation: "        ",
+        lineno: 3,
       } as Todo,
       {
         task: TaskType.Done,
         text: "Done",
         indentation: "            ",
+        lineno: 4,
       } as Todo,
     ]
 
@@ -227,24 +235,28 @@ describe("TodoService", () => {
       {
         task: TaskType.NotStarted,
         text: "Pending",
+        lineno: 0,
         indentation: "",
         file: tasksFile,
       } as Todo,
       {
         task: TaskType.InProgress,
         text: "In progress",
+        lineno: 1,
         indentation: "    ",
         file: tasksFile,
       } as Todo,
       {
         task: TaskType.WontDo,
         text: "Won't do",
+        lineno: 2,
         indentation: "        ",
         file: tasksFile,
       } as Todo,
       {
         task: TaskType.Done,
         text: "Done",
+        lineno: 3,
         indentation: "            ",
         file: tasksFile,
       } as Todo,
@@ -277,6 +289,7 @@ describe("TodoService", () => {
         task: TaskType.NotStarted,
         text: "Pending",
         indentation: "",
+        lineno: 0,
         file: tasksFile,
       } as Todo,
     ]
@@ -311,18 +324,21 @@ describe("TodoService", () => {
         task: TaskType.NotStarted,
         text: "New TODO",
         indentation: "",
+        lineno: 0,
         file: newFile,
       } as Todo,
       {
         task: TaskType.NotStarted,
         text: "Old TODO",
         indentation: "",
+        lineno: 0,
         file: oldFile,
       } as Todo,
       {
         task: TaskType.NotStarted,
         text: "Mid TODO",
         indentation: "",
+        lineno: 0,
         file: midFile,
       } as Todo,
     ]
@@ -366,8 +382,7 @@ describe("TodoService", () => {
     // Act
     const todoService = new TodoService(mockFileService, MOCK_SETTINGS)
     const todos = todoService.parseTodos(taskFile.content)
-    expect(todos.length).toBe(1)
-    todos[0].file = taskFile
+    todos.forEach(todo => todo.file = taskFile)
     await todoService.saveTodos(todoFile, todos)
 
     // Assert
@@ -375,7 +390,7 @@ describe("TodoService", () => {
 \t- [ ] task item
 \t- [ ] another task item
 \t    - [ ] nested task item
-\t - [ ] top task item
+\t- [ ] top task item
 \t    - [ ] mid task item
 \t        - [ ] bottom task item
 `

--- a/src/todoService.test.ts
+++ b/src/todoService.test.ts
@@ -353,6 +353,12 @@ describe("TodoService", () => {
 - some list
     - more lists
         - [ ] task item
+- some list
+    - [ ] another task item
+        - [ ] nested task item
+- [ ] top task item
+    - [ ] mid task item
+        - [ ] bottom task item
     `)
     const todoFile = createMockFile("TODO.md", "")
     const mockFileService = new MockFileService([taskFile, todoFile])
@@ -367,6 +373,11 @@ describe("TodoService", () => {
     // Assert
     const expected = `- [Tasks.md](/Tasks.md)
 \t- [ ] task item
+\t- [ ] another task item
+\t    - [ ] nested task item
+\t - [ ] top task item
+\t    - [ ] mid task item
+\t        - [ ] bottom task item
 `
 
     const actual = todoFile.content

--- a/src/todoService.test.ts
+++ b/src/todoService.test.ts
@@ -255,9 +255,9 @@ describe("TodoService", () => {
 
     // Act
     const todoService = new TodoService(mockFileService, MOCK_SETTINGS)
-    todoService.saveTodos(todoFile, todos)
+    await todoService.saveTodos(todoFile, todos)
 
-    // Expected
+    // Assert
     const expected = `- [Tasks.md](/Tasks.md)
 \t- [ ] Pending
 \t    - [.] In progress
@@ -286,9 +286,9 @@ describe("TodoService", () => {
 
     // Act
     const todoService = new TodoService(mockFileService, MOCK_SETTINGS)
-    todoService.saveTodos(todoFile, todos)
+    await todoService.saveTodos(todoFile, todos)
 
-    // Expected
+    // Assert
     const expected = `- [Tasks & Porpoises 🐬.md](/Folder/Tasks%20&%20Porpoises%20%F0%9F%90%AC.md)
 \t- [ ] Pending
 `
@@ -332,15 +332,41 @@ describe("TodoService", () => {
 
     // Act
     const todoService = new TodoService(mockFileService, MOCK_SETTINGS)
-    todoService.saveTodos(todoFile, todos)
+    await todoService.saveTodos(todoFile, todos)
 
-    // Expected
+    // Assert
     const expected = `- [Old.md](/Old.md)
 \t- [ ] Old TODO
 - [Mid.md](/Mid.md)
 \t- [ ] Mid TODO
 - [New.md](/New.md)
 \t- [ ] New TODO
+`
+
+    const actual = todoFile.content
+    expect(actual).toEqual(expected)
+  })
+
+  test("Whole shebang formats TODO.md correctly with task items nested under normal lists", async () => {
+    // Arrange
+    const taskFile = createMockFile("Tasks.md", `
+- some list
+    - more lists
+        - [ ] task item
+    `)
+    const todoFile = createMockFile("TODO.md", "")
+    const mockFileService = new MockFileService([taskFile, todoFile])
+
+    // Act
+    const todoService = new TodoService(mockFileService, MOCK_SETTINGS)
+    const todos = todoService.parseTodos(taskFile.content)
+    expect(todos.length).toBe(1)
+    todos[0].file = taskFile
+    await todoService.saveTodos(todoFile, todos)
+
+    // Assert
+    const expected = `- [Tasks.md](/Tasks.md)
+\t- [ ] task item
 `
 
     const actual = todoFile.content

--- a/src/todoService.ts
+++ b/src/todoService.ts
@@ -93,7 +93,10 @@ class TodoService {
     return todos
   }
 
-  async saveTodos(file: IFile, todos: Todo[]): Promise<void> {
+  /**
+   * Save the task items to the TODO file
+   */
+  async saveTodos(todoFile: IFile, todos: Todo[]): Promise<void> {
     let data = ""
 
     // Sort oldest-to-newest
@@ -132,7 +135,7 @@ class TodoService {
       })
     })
 
-    this.fileService.updateFile(file, data)
+    this.fileService.updateFile(todoFile, data)
   }
 
   private async getShouldExcludeFile(file: IFile): Promise<boolean> {


### PR DESCRIPTION
closes #15

Given the following markdown:

```markdown
- some list
	- that is deeply nested
		- [ ] with a TODO
```

it used to generate this

```markdown
- [test nested](test%20nested.md)
			- [ ] with a TODO
```

but now it generates this

```markdown
- [test nested](test%20nested.md)
	- [ ] with a TODO
```